### PR TITLE
Fix typo in achievements.json (Trough the Trench)

### DIFF
--- a/resources/js/achievements.json
+++ b/resources/js/achievements.json
@@ -208,7 +208,7 @@
     },
     {
         "id": "PTTT",
-        "name": "Trough the Trench",
+        "name": "Through the Trench",
         "type": "Party"
     },
     {


### PR DESCRIPTION
Fix the typo in "Trough the Trench" for "Through the Trench"