### PR TITLE
Correct the name of scenario no. 50

### DIFF
--- a/resources/js/scenarios.json
+++ b/resources/js/scenarios.json
@@ -2109,7 +2109,7 @@
         {
             "id": 50,
             "game": "gh",
-            "name": "Ghost Forrest",
+            "name": "Ghost Fortress",
             "coordinates": {
                 "name": "C-17",
                 "x": 75.74444,


### PR DESCRIPTION
Scenario was incorrectly named “Ghost Forrest”, should be “Ghost Fortress”