### PR TITLE
Updates for CS scenario 55 - Fixed treasure item #

### DIFF
--- a/resources/js/scenarios-cs.json
+++ b/resources/js/scenarios-cs.json
@@ -1603,7 +1603,7 @@
             "chapter_id": 104,
             "treasures": {
                 "44": "“Mana Medicine” (Item 60)",
-                "31": "“Drake's Blood” (Item 14)"
+                "31": "“Drake's Blood” (Item 59)"
             },
             "rewards": [
                 "+1 prosperity",


### PR DESCRIPTION
In scenario 55 the treasure 31 incorrectly listed as item 14, fixed to item 59.

Fixes #235 