### PR TITLE
Fix/231 cs scenario50

### DIFF
--- a/resources/js/achievements.json
+++ b/resources/js/achievements.json
@@ -661,7 +661,11 @@
         "id": "PCSIA",
         "name": "Inox Alliance",
         "type": "Party",
-        "game": "cs"
+        "game": "cs",
+        "is_manual": true,
+        "cards": [
+            "C-42"
+        ]
     },
     {
         "id": "PCSGB",


### PR DESCRIPTION
Changes CS Achievement "PCSIA" to be manually selected from the Achievements screen. In turn, this allows Scenario CS50 to be unlocked.

Submitted as draft since I wasn't sure exactly if I covered all the files for the page to find it. 