### PR TITLE
Reverse FH scenario 4 outcome

### DIFF
--- a/resources/js/services/ChoiceService.js
+++ b/resources/js/services/ChoiceService.js
@@ -114,10 +114,10 @@ class ChoiceService {
                     callback: (value) => {
                         if (value) {
                             if (value === 1) {
-                                this.scenarioRepository.choose(scenario, '5,7,8');
+                                this.scenarioRepository.choose(scenario, '6,7,8');
                             }
                             if (value === 2) {
-                                this.scenarioRepository.choose(scenario, '6,7,8');
+                                this.scenarioRepository.choose(scenario, '5,7,8');
                             }
                         } else {
                             // reset


### PR DESCRIPTION
The scenarios unlocked at the end of FH scenario 4 are currently around the wrong way; this just fixes that.