### PR TITLE
Fix retaliate translation

### DIFF
--- a/resources/js/components/elements/AddLinksAndIcons.vue
+++ b/resources/js/components/elements/AddLinksAndIcons.vue
@@ -97,7 +97,7 @@ export default {
                     '{MOVE}': this.$t('Move') + ' <webp src="/img/icons/general/move.png" width="20" class="inline"/>',
                     '{JUMP}': this.$t('Jump') + ' <webp src="/img/icons/general/jump.png" width="20" class="inline"/>',
                     '{FLYING}': this.$t('Flying') + ' <webp src="/img/icons/general/flying.png" width="20" class="inline"/>',
-                    '{RETALIATE}': this.$t('REGENERATE') + ' <webp src="/img/icons/general/retaliate.png" width="20" class="inline"/>',
+                    '{RETALIATE}': this.$t('Retaliate') + ' <webp src="/img/icons/general/retaliate.png" width="20" class="inline"/>',
                     '{SWING}': this.$t('SWING') + ' <webp src="/img/icons/general/swing.png" width="20" class="inline"/>',
                     '{TELEPORT}': this.$t('TELEPORT') + ' <webp src="/img/icons/general/teleport.png" width="20" class="inline"/>',
                     '{TARGET}': this.$t('TARGET') + ' <webp src="/img/icons/general/target.png" width="20" class="inline"/>',


### PR DESCRIPTION
Retaliate was translated with regenerate translation
eg.
item 46 spiked shield description:
![image](https://github.com/teamducro/gloomhaven-storyline/assets/51273591/e7b6c505-f916-4049-a07d-99a595600a39)

in items list the ability was incorrectly translated with "regenerate"
![image](https://github.com/teamducro/gloomhaven-storyline/assets/51273591/5b71abfa-be80-43c1-b287-3e0ef93161f5)

with the fix applied:
![image](https://github.com/teamducro/gloomhaven-storyline/assets/51273591/f2487f59-a738-4d62-9967-b1449bf133b1)

