### PR TITLE
Limit cross-game items available in Frosthaven

### DIFF
--- a/cypress/integration/items.spec.js
+++ b/cypress/integration/items.spec.js
@@ -164,6 +164,25 @@ describe('Items', () => {
         cy.get('#items').contains('Jet Boots').should('exist');
     });
 
+    it('It can use items from other games in FH', () => {
+        utilities.enableGame('fh');
+        utilities.switchGame('fh');
+        
+        cy.visit('/tracker/#/items');
+        cy.get('.items-to-add-dropdown button').click();
+        utilities.scrollTo('50%');
+        cy.get('#cross-game-items-enabled-checkbox').click();
+        cy.get('#gh25').click();
+
+        utilities.scrollTo('100%', true);
+        cy.get('#items').contains('Jagged Sword').should('exist');
+
+        // Make sure it also works after a reload!
+        cy.reload(true);
+        utilities.scrollTo('100%', true);
+        cy.get('#items').contains('Jagged Sword').should('exist');
+    });
+
     it('It can add items to characters', () => {
         // Campaign with Brute without items
         cy.visit('/tracker/#/shared/1/local/N4Rozg5gFgtAjAIgFyjAFxASwL4BpzQwBMADEcqhjvpLKQMwXhV4F0kAsT6WrtxJAKzcWNQqQBsI3mPYB2adXAAzAMYwAnFJTMZIAIYQAwgCUm+sAG0EAcVMBZBAF1W+uycc79AdxBx8qgD2-iAANiAkfFDACPoATqpQmABuAKYAJkZQ8fqqaKlxYBR4CIk5eQUAqgB2oYGqANZFKAgAQmZIfrgIRgASyF0IAMoA6gP+CAAqAJLj3UNGcwj2k+OsZTGpGoJycNscMOkSWjAcqhKpMAAcEnBEmnKCJCQS+kTHqVxIbWYlqphoACeFAQiE6E3I4O6jChCC+g2EsO0gwUsKuSw0SzgJCxYMGdyxMPx8ImcER+ORpNR+PRsL2S1IDLxEMhgyIRIhJO6RHJEMp3OpENpbMxsPoOPBfzigTAYBs+gAtqlpvkFc0YtABiRugArQJoUJa7qqZoRKUyuWK5WqsAAUWq+gARqEMkaQOltVh0sBWAAHTAhOLahDS-TpEHM7lLDndLkIXndfkIQXdYUTUX4iX4yOg1mkmOguNkrFJuAp0Fp7r02GMms5oh57kFohxnkMpNEctESsIIgZibitb4ACuPr+2TiuXycRgWx2e0EByOJzOF2ut3uGkez1e7w0nxBTswoQBmFS6pKR5PQIACgUADKpNKGlqQ6rD0KhaHId+f2M-j8v3jAC-wQbRfyA1EINTECgNFCDx1SRoL26CBAlCcMkGDTBMJ+BBugBVI1WKboXWfZAJgdJVkDaOJh3yfCEF9AomhIhAAEdh3PNA2LiVI0EwPilWqNBmmDYdhxwmi512fZDmOCRTnOS4bjuB4nheN4Pi4boAA9fWQSJsCAA/items');

--- a/cypress/utilities.js
+++ b/cypress/utilities.js
@@ -165,6 +165,18 @@ export default {
         this.assertCount('#' + table + ' tbody tr', count);
     },
 
+    enableGame(game) {
+        cy.visit('/tracker/#/settings');
+        
+        cy.get('#' + game + '-enabled').invoke('is', ':checked').then(checked => {
+            if (!checked) {
+                cy.get('@checkbox').check();
+            }
+        });
+
+        switchGame(game);
+    },
+
     switchGame(game) {
         cy.get('button').contains('menu').click();
         cy.get('.game-switch .mdc-select__selected-text').click();

--- a/cypress/utilities.js
+++ b/cypress/utilities.js
@@ -167,12 +167,7 @@ export default {
 
     enableGame(game) {
         cy.visit('/tracker/#/settings');
-        
-        cy.get('#' + game + '-enabled').invoke('is', ':checked').then(checked => {
-            if (!checked) {
-                cy.get('@checkbox').check();
-            }
-        });
+        cy.get('#' + game + '-enabled').check();
     },
 
     switchGame(game) {

--- a/cypress/utilities.js
+++ b/cypress/utilities.js
@@ -173,8 +173,6 @@ export default {
                 cy.get('@checkbox').check();
             }
         });
-
-        switchGame(game);
     },
 
     switchGame(game) {

--- a/resources/js/models/CampaignSheet.js
+++ b/resources/js/models/CampaignSheet.js
@@ -225,13 +225,15 @@ class CampaignSheet {
 
     fillDefaultCrossGameItems() {
         if (_.isEmpty(this.crossGameItems)) {
-                this.crossGameItems = {
-                10: false,
-                25: false,
-                72: false,
-                105: false,
-                109: false,
-                116: false,
+            this.crossGameItems = {
+                'gh': {
+                    10: false,
+                    25: false,
+                    72: false,
+                    105: false,
+                    109: false,
+                    116: false,
+                },
             }
         }
     }

--- a/resources/js/models/CampaignSheet.js
+++ b/resources/js/models/CampaignSheet.js
@@ -226,10 +226,12 @@ class CampaignSheet {
     fillDefaultCrossGameItems() {
         if (_.isEmpty(this.crossGameItems)) {
                 this.crossGameItems = {
-                'gh': false,
-                'jotl': false,
-                'cs': false,
-                'fh': false,
+                10: false,
+                25: false,
+                72: false,
+                105: false,
+                109: false,
+                116: false,
             }
         }
     }

--- a/resources/js/models/CampaignSheet.js
+++ b/resources/js/models/CampaignSheet.js
@@ -224,7 +224,7 @@ class CampaignSheet {
     }
 
     fillDefaultCrossGameItems() {
-        if (_.isEmpty(this.crossGameItems)) {
+        if (_.isEmpty(this.crossGameItems) || typeof this.crossGameItems['gh'] !== 'object') {
             this.crossGameItems = {
                 'gh': {
                     10: false,

--- a/resources/js/models/CampaignSheet.js
+++ b/resources/js/models/CampaignSheet.js
@@ -223,18 +223,39 @@ class CampaignSheet {
         }
     }
 
+    resetCrossGameItems() {
+        this.crossGameItems = {
+            'gh': {
+                10: false,
+                25: false,
+                72: false,
+                105: false,
+                109: false,
+                116: false,
+            },
+            'jotl': {},
+            'cs': {}
+        }
+    }
+
     fillDefaultCrossGameItems() {
-        if (_.isEmpty(this.crossGameItems) || typeof this.crossGameItems['gh'] !== 'object') {
-            this.crossGameItems = {
-                'gh': {
-                    10: false,
-                    25: false,
-                    72: false,
-                    105: false,
-                    109: false,
-                    116: false,
-                },
-            }
+        if (_.isEmpty(this.crossGameItems)) {
+            this.resetCrossGameItems();
+        }
+        else if (typeof this.crossGameItems['gh'] !== 'object') {
+            this.resetCrossGameItems();
+
+            // Check if any characters have some cross-game items that should transfer over
+            collect(this.characters).each((character) => {
+                collect(character.items).each((available, itemId) => {
+                    const splitIndex = itemId.indexOf('-');
+                    const itemGame = itemId.substring(0, splitIndex);
+                    if (itemGame !== 'fh') {
+                        const itemNumber = itemId.slice(splitIndex + 1)
+                        this.crossGameItems[itemGame][itemNumber] = true;
+                    }
+                });
+            });
         }
     }
 

--- a/resources/js/pages/Characters.vue
+++ b/resources/js/pages/Characters.vue
@@ -363,19 +363,25 @@ export default {
 
                 // Add items from other games, if enabled.
                 if (this.sheet.crossGameItemsEnabled) {
+                    const otherGames = collect(this.sheet.crossGameItems).filter().keys().all();
+                    let otherGameHandler;
+
                     if (this.currentGame === Game.fh) {
-                        const otherItems = collect(this.sheet.crossGameItems[Game.gh]).filter().keys().all();
-                        const ghItems = this.prependGame(Game.gh, otherItems);
-                        items = collect({...items.all(), ...this.itemRepository.findMany(ghItems).all()})
+                        otherGameHandler = (otherGame => {
+                            const otherGameItems = collect(this.sheet.crossGameItems[otherGame]).filter().keys().all();
+                            const otherItems = this.prependGame(otherGame, otherGameItems);
+                            items = collect({...items.all(), ...this.itemRepository.findMany(otherItems).all()})
+                        });
                     }
                     else {
-                        const otherGames = collect(this.sheet.crossGameItems).filter().keys().all();
-                        otherGames.forEach(otherGame => {
+                        otherGameHandler = (otherGame => {
                             if (otherGame !== this.currentGame) {
                                 items = collect({...items.all(), ...this.itemRepository.fromGame(otherGame).all()});
                             }
                         });
                     }
+
+                    otherGames.forEach(otherGameHandler);
                 }
 
                 this.items = items.all()

--- a/resources/js/pages/Characters.vue
+++ b/resources/js/pages/Characters.vue
@@ -364,7 +364,7 @@ export default {
                 // Add items from other games, if enabled.
                 if (this.sheet.crossGameItemsEnabled) {
                     if (this.currentGame === Game.fh) {
-                        const otherItems = collect(this.sheet.crossGameItems).filter().keys().all();
+                        const otherItems = collect(this.sheet.crossGameItems[Game.gh]).filter().keys().all();
                         const ghItems = this.prependGame(Game.gh, otherItems);
                         items = collect({...items.all(), ...this.itemRepository.findMany(ghItems).all()})
                     }

--- a/resources/js/pages/Characters.vue
+++ b/resources/js/pages/Characters.vue
@@ -363,12 +363,19 @@ export default {
 
                 // Add items from other games, if enabled.
                 if (this.sheet.crossGameItemsEnabled) {
-                    const otherGames = collect(this.sheet.crossGameItems).filter().keys().all();
-                    otherGames.forEach(otherGame => {
-                        if (otherGame !== this.currentGame) {
-                            items = collect({...items.all(), ...this.itemRepository.fromGame(otherGame).all()});
-                        }
-                    });
+                    if (this.currentGame === Game.fh) {
+                        const otherItems = collect(this.sheet.crossGameItems).filter().keys().all();
+                        const ghItems = this.prependGame(Game.gh, otherItems);
+                        items = collect({...items.all(), ...this.itemRepository.findMany(ghItems).all()})
+                    }
+                    else {
+                        const otherGames = collect(this.sheet.crossGameItems).filter().keys().all();
+                        otherGames.forEach(otherGame => {
+                            if (otherGame !== this.currentGame) {
+                                items = collect({...items.all(), ...this.itemRepository.fromGame(otherGame).all()});
+                            }
+                        });
+                    }
                 }
 
                 this.items = items.all()

--- a/resources/js/pages/Items.vue
+++ b/resources/js/pages/Items.vue
@@ -47,12 +47,28 @@
                                              :checked.sync="sheet.crossGameItemsEnabled"
                                              @change="refreshItems();store()"/>
 
-                            <ul v-if="sheet.crossGameItemsEnabled">
-                                <li v-for="code in Object.keys(sheet.crossGameItems)" v-if="code !== currentGame && currentGame !== 'fh'">
+                            <ul v-if="sheet.crossGameItemsEnabled && currentGame !== 'fh'">
+                                <li v-for="code in Object.keys(sheet.crossGameItems)" v-if="code !== currentGame">
                                     <checkbox-with-label :id="code+'-items'"
                                                          :label="$t(code)"
                                                          :checked.sync="sheet.crossGameItems[code]"
                                                          @change="refreshItems();store()"/>
+                                </li>
+                            </ul>
+                            <ul v-if="sheet.crossGameItemsEnabled && currentGame === 'fh'">
+                                <li class="flex items-center">
+                                    <checkbox-with-label :id="gh-10"
+                                                         :label="10"/>
+                                    <checkbox-with-label :id="gh-25"
+                                                         :label="25"/>
+                                    <checkbox-with-label :id="gh-72"
+                                                         :label="72"/>
+                                    <checkbox-with-label :id="gh-105"
+                                                         :label="105"/>
+                                    <checkbox-with-label :id="gh-109"
+                                                         :label="109"/>
+                                    <checkbox-with-label :id="gh-116"
+                                                         :label="116"/>
                                 </li>
                             </ul>
                         </div>

--- a/resources/js/pages/Items.vue
+++ b/resources/js/pages/Items.vue
@@ -47,32 +47,33 @@
                                              :checked.sync="sheet.crossGameItemsEnabled"
                                              @change="refreshItems();store()"/>
 
-                            <ul v-if="sheet.crossGameItemsEnabled && currentGame !== 'fh'">
-                                <li v-for="code in Object.keys(sheet.crossGameItems)" v-if="code !== currentGame">
-                                    <checkbox-with-label :id="code+'-items'"
-                                                         :label="$t(code)"
-                                                         :checked.sync="sheet.crossGameItems[code]"
-                                                         @change="refreshItems();store()"/>
-                                </li>
-                            </ul>
-                            <ul v-if="sheet.crossGameItemsEnabled && currentGame === 'fh'">
-                                <li class="flex items-center">
-                                    <checkbox-with-label :id="gh-10"
-                                                         :label="10"/>
-                                    <checkbox-with-label :id="gh-25"
-                                                         :label="25"/>
-                                    <checkbox-with-label :id="gh-72"
-                                                         :label="72"/>
-                                    <checkbox-with-label :id="gh-105"
-                                                         :label="105"/>
-                                    <checkbox-with-label :id="gh-109"
-                                                         :label="109"/>
-                                    <checkbox-with-label :id="gh-116"
-                                                         :label="116"/>
-                                </li>
-                            </ul>
+                            <template v-if="sheet.crossGameItemsEnabled">
+                                <ul v-if="currentGame !== 'fh'">
+                                    <li v-for="code in Object.keys(sheet.crossGameItems)" v-if="code !== currentGame">
+                                        <checkbox-with-label :id="code+'-items'"
+                                                            :label="$t(code)"
+                                                            :checked.sync="sheet.crossGameItems[code]"
+                                                            @change="refreshItems();store()"/>
+                                    </li>
+                                </ul>
+                                <ul v-else>
+                                    <li class="flex items-center">
+                                        <checkbox-with-label :id="gh-10"
+                                                            :label="10"/>
+                                        <checkbox-with-label :id="gh-25"
+                                                            :label="25"/>
+                                        <checkbox-with-label :id="gh-72"
+                                                            :label="72"/>
+                                        <checkbox-with-label :id="gh-105"
+                                                            :label="105"/>
+                                        <checkbox-with-label :id="gh-109"
+                                                            :label="109"/>
+                                        <checkbox-with-label :id="gh-116"
+                                                            :label="116"/>
+                                    </li>
+                                </ul>
+                            </template>
                         </div>
-
                     </div>
                 </dropdown>
             </div>

--- a/resources/js/pages/Items.vue
+++ b/resources/js/pages/Items.vue
@@ -59,9 +59,11 @@
                                 <template v-else>
                                     <h2 class="ml-2">{{ $t('Gloomhaven Items') }}</h2>
                                     <ul class="flex">
-                                        <li v-for="code in Object.keys(sheet.crossGameItems)">
-                                            <checkbox-with-label :id="'gh-'+code"
-                                                                :label="$t(code)"/>
+                                        <li v-for="code in Object.keys(sheet.crossGameItems[Game.gh])">
+                                            <checkbox-with-label :id="Game.gh+code"
+                                                                :label="$t(code)"
+                                                                :checked.sync="sheet.crossGameItems[Game.gh][code]"
+                                                                @change="refreshItems();store()"/>
                                         </li>
                                     </ul>
                                 </template>
@@ -276,9 +278,9 @@ export default {
 
             // Add items from other games, if enabled.
             if (this.sheet.crossGameItemsEnabled) {
-                if (this.currentGame === 'fh') {
-                    // Frosthaven dictates only adding specific items from other games
-                    const ghItems = this.prependGame('gh', [10, 25, 72, 105, 109, 116]);
+                if (this.currentGame === Game.fh) {
+                    const otherItems = collect(this.sheet.crossGameItems[Game.gh]).filter().keys().all();
+                    const ghItems = this.prependGame(Game.gh, otherItems);
                     items = collect({...items.all(), ...this.itemRepository.findMany(ghItems).all()});
                 }
                 else {

--- a/resources/js/pages/Items.vue
+++ b/resources/js/pages/Items.vue
@@ -48,7 +48,7 @@
                                              @change="refreshItems();store()"/>
 
                             <ul v-if="sheet.crossGameItemsEnabled">
-                                <li v-for="code in Object.keys(sheet.crossGameItems)" v-if="code !== currentGame">
+                                <li v-for="code in Object.keys(sheet.crossGameItems)" v-if="code !== currentGame && currentGame !== 'fh'">
                                     <checkbox-with-label :id="code+'-items'"
                                                          :label="$t(code)"
                                                          :checked.sync="sheet.crossGameItems[code]"
@@ -266,18 +266,25 @@ export default {
 
             // Add items from other games, if enabled.
             if (this.sheet.crossGameItemsEnabled) {
-                const otherGames = collect(this.sheet.crossGameItems).filter().keys().all();
-                otherGames.forEach(game => {
-                    if (game !== this.currentGame) {
-                        if (game === 'gh' && this.currentGame !== 'jotl') {
-                            const ghItems = this.calculateItemsGh([], this.sheet.prosperityIndex);
-                            items = collect({...items.all(), ...this.itemRepository.findMany(ghItems).all()});
-                        } else {
-                            // Add all items for games without prosperity.
-                            items = collect({...items.all(), ...this.itemRepository.fromGame(game).all()});
+                if (this.currentGame === 'fh') {
+                    // Frosthaven dictates only adding specific items from other games
+                    const ghItems = this.prependGame('gh', [10, 25, 72, 105, 109, 116]);
+                    items = collect({...items.all(), ...this.itemRepository.findMany(ghItems).all()});
+                }
+                else {
+                    const otherGames = collect(this.sheet.crossGameItems).filter().keys().all();
+                    otherGames.forEach(game => {
+                        if (game !== this.currentGame) {
+                            if (game === 'gh' && this.currentGame !== 'jotl') {
+                                const ghItems = this.calculateItemsGh([], this.sheet.prosperityIndex);
+                                items = collect({...items.all(), ...this.itemRepository.findMany(ghItems).all()});
+                            } else {
+                                // Add all items for games without prosperity.
+                                items = collect({...items.all(), ...this.itemRepository.fromGame(game).all()});
+                            }
                         }
-                    }
-                });
+                    });
+                }
             }
 
             this.items = items

--- a/resources/js/pages/Items.vue
+++ b/resources/js/pages/Items.vue
@@ -56,22 +56,15 @@
                                                             @change="refreshItems();store()"/>
                                     </li>
                                 </ul>
-                                <ul v-else>
-                                    <li class="flex items-center">
-                                        <checkbox-with-label :id="gh-10"
-                                                            :label="10"/>
-                                        <checkbox-with-label :id="gh-25"
-                                                            :label="25"/>
-                                        <checkbox-with-label :id="gh-72"
-                                                            :label="72"/>
-                                        <checkbox-with-label :id="gh-105"
-                                                            :label="105"/>
-                                        <checkbox-with-label :id="gh-109"
-                                                            :label="109"/>
-                                        <checkbox-with-label :id="gh-116"
-                                                            :label="116"/>
-                                    </li>
-                                </ul>
+                                <template v-else>
+                                    <h2 class="ml-2">{{ $t('Gloomhaven Items') }}</h2>
+                                    <ul class="flex">
+                                        <li v-for="code in Object.keys(sheet.crossGameItems)">
+                                            <checkbox-with-label :id="'gh-'+code"
+                                                                :label="$t(code)"/>
+                                        </li>
+                                    </ul>
+                                </template>
                             </template>
                         </div>
                     </div>


### PR DESCRIPTION
As described in #292, only certain items from other games are supposed to be available in Frosthaven. This change enforces that by presenting the user options for which specific items from Gloomhaven should be included.

I changed the `crossGameItems` object in the `CampaignSheet` (which is essentially only used by Frosthaven) to include specific items that can be enabled. The list of items right now only includes what is listed in the base Frosthaven rules - it's possible others (including from other games) should be added later, but I'm trying to avoid spoilers. :) `Characters` was similarly updated to account for this change.

In the event that existing storage is loaded, I'm checking the schema of the `crossGameItems` objects and re-initializing it if necessary. This is going to potentially reset existing Frosthaven campaigns but attempt to bring over any items that characters might already have. I tested that with existing storage of some items included to characters, those items appear (both on the Items and Character pages) as expected after using the new version of the app.

I'm including a basic test that validates the behavior of this state. I also did some testing manually be enabling and disabling the cross-game items here, including making sure they would show up in the list in the Characters UI when searching. Those seemed to be the only places making use of `crossGameItems`.

<img width="1101" alt="Screenshot 2024-07-03 at 11 02 20 PM" src="https://github.com/teamducro/gloomhaven-storyline/assets/1330113/a768c6d4-b1ca-462b-84b8-39da28f52772">

<img width="870" alt="Screenshot 2024-07-05 at 10 47 15 PM" src="https://github.com/teamducro/gloomhaven-storyline/assets/1330113/165443c2-4a35-450f-a41b-3774e29ba3c7">