### PR TITLE
Correct Muscle Potion and Circlet of Elements

### DIFF
--- a/resources/js/items-fh.json
+++ b/resources/js/items-fh.json
@@ -893,7 +893,7 @@
         "id": 90,
         "name": "Muscle Potion",
         "count": 2,
-        "resources": { "rockroot": 1, "flamefruit": 1 },
+        "resources": { "axenut": 1, "flamefruit": 1 },
         "slot": "Small Item",
         "source": "Alchemy",
         "desc": "During your turn, perform {STRENGTHEN.fh} self",
@@ -1207,7 +1207,8 @@
         "cost": 25,
         "slot": "Head",
         "source": "Initially Available",
-        "desc": "During your turn, perform {ANY_X}: {ANY}"
+        "desc": "During your turn, perform {ANY_X}: {ANY}",
+        "spent": true
     },
     {
         "id": 122,


### PR DESCRIPTION
Issue 330: Changed resources of Muscle Potion to axenut: 1, flamefruit: 1

Issue 330: Added spent: true to Circlet of Elements.