### PR TITLE
fix: show select perk suggestion

### DIFF
--- a/cypress/integration/characters.spec.js
+++ b/cypress/integration/characters.spec.js
@@ -90,12 +90,12 @@ describe('Character', () => {
         utilities.openCharacter();
 
         for (let i = 0; i <= 9; i++) {
-            cy.get(`#perk-${i}-0-1`).click();
+            cy.get(`#perk-${i}-0`).click();
         }
 
         utilities.scrollTo('60%');
         cy.get('#open-modifier-deck').click();
-        cy.contains('Attack modifier deck');
+        cy.contains('Attack Modifier Deck');
 
         utilities.assertCount('.mdc-dialog__content ul.grid li', 12);
     });
@@ -205,11 +205,11 @@ describe('Character', () => {
 
         cy.get('p').contains(message).should('exist');
 
-        cy.get('#perk-8-0-1').click({force: true});
+        cy.get('#perk-8-0').click({force: true});
 
         cy.get('p').contains(message).should('exist');
 
-        cy.get('#perk-9-0-1').click();
+        cy.get('#perk-9-0').click();
 
         cy.get('p').contains(message).should('not.exist');
     });
@@ -222,7 +222,7 @@ describe('Character', () => {
         cy.get('input[aria-labelledby="level"]').clear({force: true}).type('2{enter}');
         cy.get('input[aria-labelledby="xp"]').clear({force: true}).type('50{enter}');
         cy.get('input[aria-labelledby="gold"]').clear({force: true}).type('50{enter}');
-        cy.get('#perk-0-0-1').click({force: true});
+        cy.get('#perk-0-0').click({force: true});
         cy.get('input[name="items"]').click();
         cy.get('li').contains('Boots of Striding').click();
         utilities.closeModel();
@@ -242,7 +242,7 @@ describe('Character', () => {
         cy.get('input[aria-labelledby="xp"]').should('have.value', '50');
         cy.get('input[aria-labelledby="gold"]').should('have.value', '50');
         cy.get('#check1').should('be.checked');
-        cy.get('#perk-0-0-1').should('be.checked');
+        cy.get('#perk-0-0').should('be.checked');
         cy.get('#notes').should('have.value', 'Foo Bar');
         cy.get('h3').contains('#510 Seeker of Xorn');
         cy.get('#pq-0-0').should('be.checked');
@@ -258,7 +258,7 @@ describe('Character', () => {
             cy.get('input[aria-labelledby="level"]').should('be.disabled');
             cy.get('input[aria-labelledby="xp"]').should('be.disabled');
             cy.get('input[aria-labelledby="gold"]').should('be.disabled');
-            cy.get('#perk-0-0-1').should('be.disabled');
+            cy.get('#perk-0-0').should('be.disabled');
             cy.get('input[name="items"]').should('be.disabled');
             cy.get('#notes').should('be.disabled');
             cy.get('input[aria-labelledby="personal-quests"]').should('be.disabled');

--- a/resources/js/components/presenters/charecters/Perks.vue
+++ b/resources/js/components/presenters/charecters/Perks.vue
@@ -68,7 +68,7 @@ export default {
     },
     computed: {
         perkCount() {
-            return Object.entries(this.perks).reduce((sum, [i, perk]) => sum + this.character.perkDescriptions[i].size * perk.filter(Boolean).length, 0);
+            return Object.values(this.perks).flatMap(perk => perk.filter(Boolean)).length;
         },
         minimalPerks() {
             return (this.character.retirements || 0)


### PR DESCRIPTION
"you may select an additional perk" message disappeared after this commit https://github.com/teamducro/gloomhaven-storyline/commit/1084cda8342d74652c38247bbb377716a7790446

<details>
<summary>Before</summary>
<img width="427" height="793" alt="image" src="https://github.com/user-attachments/assets/78997989-44ed-4430-aabc-6e2277d263ce" />
</details>

<details>
<summary>Now</summary>
<img width="431" height="833" alt="image" src="https://github.com/user-attachments/assets/951e5c2e-72b5-47b9-b70f-885672b32463" />
</details>

also fix tests to use new id structure
