### PR TITLE
Add character name tooltips

### DIFF
--- a/cypress/e2e/tracker/party.cy.js
+++ b/cypress/e2e/tracker/party.cy.js
@@ -168,6 +168,41 @@ describe('Party', () => {
         cy.get('#scenarios').contains('Caravan Escort').should('be.visible');
     });
 
+    it('It shows lock tooltip on locked party characters and updates after unlock', () => {
+        cy.visit('/tracker/#/party');
+        utilities.scrollTo('100%', true);
+
+        cy.get('#character-SK').should('have.attr', 'title', 'Locked');
+        cy.get('label[for="character-SK"]').should('have.attr', 'title', 'Locked');
+
+        cy.get('#character-SK').click();
+        cy.get('#character-SK').should('not.have.attr', 'title', 'Locked');
+        cy.get('label[for="character-SK"]').should('not.have.attr', 'title', 'Locked');
+    });
+
+    it('It updates character tooltips when switching games', () => {
+        cy.visit('/tracker/#/party');
+        utilities.scrollTo('100%', true);
+
+        cy.get('#character-BR').should('have.attr', 'title', 'Brute');
+        cy.get('label[for="character-BR"]').should('have.attr', 'title', 'Brute');
+
+        cy.get('#character-DF').should('have.attr', 'title', 'Locked');
+        cy.get('label[for="character-DF"]').should('have.attr', 'title', 'Locked');
+
+        utilities.enableGame('fh');
+        utilities.switchGame('fh');
+
+        cy.visit('/tracker/#/party');
+        utilities.scrollTo('100%', true);
+
+        cy.get('#character-DF').should('have.attr', 'title', 'Drifter');
+        cy.get('label[for="character-DF"]').should('have.attr', 'title', 'Drifter');
+        
+        cy.get('#character-BR').should('have.attr', 'title', 'Locked');
+        cy.get('label[for="character-BR"]').should('have.attr', 'title', 'Locked');
+    });
+
     it('it unlocks envelope X', () => {
         cy.visit('/tracker/#/party');
         utilities.scrollTo('100%', true);

--- a/resources/js/components/elements/Checkbox.vue
+++ b/resources/js/components/elements/Checkbox.vue
@@ -6,6 +6,7 @@
                v-model="isChecked"
                :disabled="isDisabled"
                :id="id"
+               :title="title"
                @change="changed"/>
         <div class="mdc-checkbox__background">
             <svg class="mdc-checkbox__checkmark"
@@ -43,6 +44,10 @@ export default {
         autoDisable: {
             type: Boolean,
             default: true
+        },
+        title: {
+            type: String,
+            default: undefined
         },
     },
     data() {

--- a/resources/js/components/presenters/party/UnlockCharacters.vue
+++ b/resources/js/components/presenters/party/UnlockCharacters.vue
@@ -1,13 +1,15 @@
 <template>
     <ul class="flex flex-row flex-wrap -mx-2">
         <li v-for="(checked, id) in sheet.characterUnlocks" :key="id" class="flex items-center"
-            :class="'order-'+sheet.characterOrder[id]">
+            :class="'order-'+sheet.characterOrder[id]"
+            :title="characterTooltip(id)">
             <checkbox group="items"
                       :id="'character-'+id"
                       :checked="checked"
                       :disabled="sheet.starterCharacters.includes(id)"
+                      :title="characterTooltip(id)"
                       @change="(_, isChecked) => {unlockCharacter(id, isChecked)}"></checkbox>
-            <label class="w-8 font-title" :for="'character-'+id">
+            <label class="w-8 font-title" :for="'character-'+id" :title="characterTooltip(id)">
                 <character-icon class="w-6 -mb-2 inline-block" :character="id"/>
             </label>
         </li>
@@ -18,6 +20,7 @@
 import Sheet from "../../../models/Sheet";
 import CampaignSheet from "../../../models/CampaignSheet";
 import ScenarioRepository from "../../../repositories/ScenarioRepository";
+import CharacterRepository from "../../../repositories/CharacterRepository";
 
 export default {
     props: {
@@ -28,10 +31,22 @@ export default {
     },
     data() {
         return {
+            characterRepository: new CharacterRepository,
             scenarioRepository: new ScenarioRepository
         }
     },
+    computed: {
+        characterNames() {
+            const characters = this.characterRepository.get(this.sheet.game);
+            return collect(characters).pluck('translatedName').items;
+        }
+    },
     methods: {
+        characterTooltip(id) {
+            return this.sheet.characterUnlocks[id]
+                ? this.$t(this.characterNames[id])
+                : this.$t('Locked');
+        },
         unlockCharacter(id, isChecked) {
             this.sheet.characterUnlocks[id] = isChecked;
             this.sheet.store();


### PR DESCRIPTION
I wanted to see the names of the character on the party sheet, so decided displaying via a tooltip would be a good approach.

This adds the `title` property to the `Checkbox` component. When unlocked, it will look up the name of the class based on the ID, otherwise will simply say "Locked" to avoid spoilers.

This was assisted with GitHub Copilot, mostly to ensure that the computed values worked as expected - it originally wanted a much more invasive approach but this seemed much more straightforward. It also helped write the couple tests I added.

<img width="211" height="179" alt="Brute" src="https://github.com/user-attachments/assets/c392c765-bf4e-4777-b4ca-b612ae6744cf" />
<img width="236" height="171" alt="Locked" src="https://github.com/user-attachments/assets/d5cca767-9d9a-4847-b76e-781eac42213a" />
<img width="246" height="132" alt="QuartermasterUnlocked" src="https://github.com/user-attachments/assets/3e02b863-cd3b-430a-98c6-0c0234d3b509" />
